### PR TITLE
Restructure nodes to support stacked charts 

### DIFF
--- a/src/scene/CMakeLists.txt
+++ b/src/scene/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(scene
 
     fontimage.cpp
     fontimage.h
+    geometrynode.cpp
+    geometrynode.h
     rootnode.cpp
     rootnode.h
     symbolimage.cpp

--- a/src/scene/annotation/annotationnode.cpp
+++ b/src/scene/annotation/annotationnode.cpp
@@ -13,10 +13,10 @@ static const QSGGeometry::AttributeSet attributeSet = { static_cast<int>(std::si
 
 static_assert(sizeof(AnnotationNode::Vertex) == 32, "Incorrect sizeof(AnnotationNode::Vertex)");
 
-AnnotationNode::AnnotationNode(const QString &tileId,
+AnnotationNode::AnnotationNode(const QString &id,
                                QSGMaterial *material,
                                const QList<AnnotationNode::Vertex> &vertices)
-    : m_tileId(tileId)
+    : m_id(id)
 {
     setMaterial(material);
 

--- a/src/scene/annotation/annotationnode.h
+++ b/src/scene/annotation/annotationnode.h
@@ -29,11 +29,11 @@ public:
                    QSGMaterial *material,
                    const QList<AnnotationNode::Vertex> &vertices);
     ~AnnotationNode();
-    const QString &tileId() const { return m_tileId; }
+    const QString &id() const { return m_id; }
 
 public:
     void updateVertices(const QList<AnnotationNode::Vertex> &vertices);
 
 private:
-    QString m_tileId;
+    QString m_id;
 };

--- a/src/scene/geometrynode.cpp
+++ b/src/scene/geometrynode.cpp
@@ -1,0 +1,11 @@
+#include "geometrynode.h"
+
+GeometryNode::GeometryNode(const QString &id)
+    : m_id(id)
+{
+}
+
+const QString &GeometryNode::id() const
+{
+    return m_id;
+}

--- a/src/scene/geometrynode.h
+++ b/src/scene/geometrynode.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QSGNode>
+#include <QString>
+
+class GeometryNode : public QSGNode
+{
+public:
+    GeometryNode() = delete;
+    GeometryNode(const QString &id);
+    const QString &id() const;
+
+private:
+    QString m_id;
+};

--- a/src/scene/include/scene/scene.h
+++ b/src/scene/include/scene/scene.h
@@ -77,16 +77,6 @@ signals:
 private:
     template <typename T>
     void removeStaleNodes(QSGNode *parent) const;
-
-    template <typename T>
-    void updateNodeData(const QString &tileId,
-                        QSGNode *parent,
-                        const QHash<QString, T *> &existingNodes,
-                        std::function<QList<typename T::Vertex>(const TileData &tileData)> getter,
-                        QSGMaterial *material);
-
-    template <typename T>
-    static QHash<QString, T *> currentNodes(const QSGNode *parent);
     void markChildrensDirtyMaterial(QSGNode *parent);
     void addTessellatorsFromModel(TileFactoryWrapper *tileFactory, int first, int last);
     void updateBox();

--- a/src/scene/polygon/polygonnode.cpp
+++ b/src/scene/polygon/polygonnode.cpp
@@ -15,10 +15,10 @@ static const QSGGeometry::Attribute attributes[2] = {
 static const QSGGeometry::AttributeSet attributeSet = { 2, 16, attributes };
 static_assert(sizeof(PolygonNode::Vertex) == 16, "Incorrect sizeof(PolygonNode::Vertex)");
 
-PolygonNode::PolygonNode(const QString &tileId,
+PolygonNode::PolygonNode(const QString &id,
                          QSGMaterial *material,
                          const QList<PolygonNode::Vertex> &vertices)
-    : m_tileId(tileId)
+    : m_id(id)
 {
     setMaterial(material);
     QSGGeometry *geometry = new QSGGeometry(attributeSet, vertices.length());

--- a/src/scene/polygon/polygonnode.h
+++ b/src/scene/polygon/polygonnode.h
@@ -20,9 +20,9 @@ public:
     PolygonNode(const QString &tileId,
                 QSGMaterial *material,
                 const QList<PolygonNode::Vertex> &vertices);
-    const QString &tileId() const { return m_tileId; }
+    const QString &id() const { return m_id; }
     void updateVertices(const QList<Vertex> &vertices);
 
 private:
-    QString m_tileId;
+    QString m_id;
 };

--- a/src/scene/rootnode.cpp
+++ b/src/scene/rootnode.cpp
@@ -2,7 +2,6 @@
 #include <QSGTexture>
 
 #include "annotation/annotationmaterial.h"
-#include "fontimage.h"
 #include "polygon/polygonmaterial.h"
 #include "rootnode.h"
 #include "symbolimage.h"

--- a/src/scene/tessellator.cpp
+++ b/src/scene/tessellator.cpp
@@ -106,7 +106,7 @@ QRectF Tessellator::computeSymbolBox(const QTransform &transform,
                   textureSymbol.roi.size());
 }
 
-QPointF Tessellator::posToMeractor(const ChartData::Position::Reader &pos)
+QPointF Tessellator::posToMercator(const ChartData::Position::Reader &pos)
 {
     return { Mercator::mercatorWidth(0, pos.getLongitude(), s_pixelsPerLon),
              Mercator::mercatorHeight(0, pos.getLatitude(), s_pixelsPerLon) };
@@ -163,7 +163,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
 
     for (const auto &chart : charts) {
         for (const auto &sounding : chart->soundings()) {
-            const auto pos = posToMeractor(sounding.getPosition());
+            const auto pos = posToMercator(sounding.getPosition());
 
             int precision = 0;
             if (sounding.getDepth() < 30) {
@@ -202,7 +202,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                 precision = 1;
             }
 
-            const auto pos = posToMeractor(rock.getPosition());
+            const auto pos = posToMercator(rock.getPosition());
             const auto depthLabel = locale.toString(rock.getDepth(), 'f', precision);
             const auto boundingBox = fontImage->boundingBox(depthLabel,
                                                          rockPointSize,
@@ -229,7 +229,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                 continue;
             }
 
-            const auto pos = posToMeractor(buoy.getPosition());
+            const auto pos = posToMercator(buoy.getPosition());
 
             // At some point this should be the color letter of the buoy
             const auto label("?");
@@ -252,7 +252,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
         }
 
         for (const auto &item : chart->landRegions()) {
-            const auto pos = posToMeractor(item.getPosition());
+            const auto pos = posToMercator(item.getPosition());
             const auto name = QString::fromStdString(item.getName());
             const auto labelBox = fontImage->boundingBox(name,
                                                          landRegionPointSize,
@@ -377,7 +377,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                 continue;
             }
 
-            const auto pos = posToMeractor(beacon.getPosition());
+            const auto pos = posToMercator(beacon.getPosition());
             const QPoint symbolSize(symbol->size.width(), symbol->size.height());
             const auto name = QString::fromStdString(beacon.getName());
             const auto metrics = fontImage->boundingBox(name,
@@ -834,7 +834,7 @@ QList<PolygonNode::Vertex> Tessellator::drawPolygons(const typename capnp::List<
 
             capnp::List<ChartData::Position>::Reader main = polygon.getMain();
             for (ChartData::Position::Reader pos : main) {
-                QPointF p = posToMeractor(pos);
+                QPointF p = posToMercator(pos);
                 polyline.push_back({ p.x(), p.y() });
             }
             polylines.push_back(polyline);
@@ -843,7 +843,7 @@ QList<PolygonNode::Vertex> Tessellator::drawPolygons(const typename capnp::List<
                 std::vector<Triangulator::Point> polyline;
 
                 for (const auto &pos : hole) {
-                    QPointF p = posToMeractor(pos);
+                    QPointF p = posToMercator(pos);
                     polyline.push_back({ p.x(), p.y() });
                 }
                 polylines.push_back(polyline);

--- a/src/scene/tessellator.cpp
+++ b/src/scene/tessellator.cpp
@@ -9,9 +9,17 @@
 #include "tilefactory/mercator.h"
 #include "tilefactory/triangulator.h"
 
+static const QColor labelColor = Qt::black;
+static const QColor symbolLabelColor = Qt::black;
 static const QColor criticalWaterColor(165, 202, 159);
 static const QColor landAreaColor(255, 240, 190);
-static const QColor builtUpAreaColor(221, 205, 153);
+static const QColor builtUpAreaColor(240, 220, 160);
+static const QColor coastLineColor = landAreaColor.darker(200);
+static const QColor builtUpAreaColorBorder = builtUpAreaColor.darker(150);
+static const QColor pontoonColor = builtUpAreaColor.darker(120);
+static const QColor pontoonBorderColor = pontoonColor.darker(150);
+static const QColor roadColor = landAreaColor.darker(120);
+static const QColor roadColorBorder = roadColor.darker(150);
 
 // Arbitrary chosen conversion factor to transform lat/lon to an internal mercator
 // projection that can be linearly transformed in scene graph/vertex shader.
@@ -207,7 +215,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  labelOffset(boundingBox, symbol.value(), LabelPlacement::Below),
                                  boundingBox,
                                  FontImage::FontType::Soundings,
-                                 QColor(0, 0, 0),
+                                 symbolLabelColor,
                                  rockPointSize,
                                  std::nullopt,
                                  std::nullopt } },
@@ -236,7 +244,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  labelOffset(labelBox, symbol.value(), LabelPlacement::Below),
                                  labelBox,
                                  FontImage::FontType::Normal,
-                                 Qt::black,
+                                 symbolLabelColor,
                                  soundingPointSize,
                                  std::nullopt } },
                              2,
@@ -257,7 +265,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  QPointF(-labelBox.width() / 2, -labelBox.height() / 2),
                                  labelBox,
                                  FontImage::FontType::Normal,
-                                 Qt::black,
+                                 labelColor,
                                  landRegionPointSize,
                                  std::nullopt } },
                              3,
@@ -282,7 +290,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  QPointF(-labelBox.width() / 2, -labelBox.height() / 2),
                                  labelBox,
                                  FontImage::FontType::Normal,
-                                 Qt::black,
+                                 labelColor,
                                  builtUpPointSize,
                                  std::nullopt } },
                              4,
@@ -318,7 +326,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  QPointF(-labelBox.width() / 2, -labelBox.height() / 2),
                                  labelBox,
                                  FontImage::FontType::Normal,
-                                 Qt::black,
+                                 symbolLabelColor,
                                  landAreaPointSize,
                                  std::nullopt } },
                              4,
@@ -355,7 +363,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  labelOffset,
                                  metrics,
                                  FontImage::FontType::Normal,
-                                 Qt::black,
+                                 symbolLabelColor,
                                  builtUpAreaPointSize,
                                  std::nullopt } },
                              4,
@@ -383,7 +391,7 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                  labelOffset(metrics, symbol.value(), LabelPlacement::Below),
                                  metrics,
                                  FontImage::FontType::Normal,
-                                 Qt::black,
+                                 symbolLabelColor,
                                  beaconPointSize,
                                  std::nullopt } },
                              5,

--- a/src/scene/tessellator.cpp
+++ b/src/scene/tessellator.cpp
@@ -124,7 +124,15 @@ TileData Tessellator::fetchData(TileFactoryWrapper *tileFactory,
                                 std::shared_ptr<const FontImage> fontImage)
 {
     Q_ASSERT(tileFactory);
-    auto charts = tileFactory->create(recipe);
+
+    std::vector<std::shared_ptr<Chart>> charts;
+
+    try {
+        charts = tileFactory->create(recipe);
+    } catch(const std::exception &e) {
+        qWarning() << "Exception in tilefactory: " << e.what();
+        return {};
+    }
 
     TileData tileData;
     QList<Symbol> symbols;

--- a/src/scene/tessellator.h
+++ b/src/scene/tessellator.h
@@ -82,7 +82,7 @@ private:
         CollisionRule collisionRule;
     };
 
-    static QPointF posToMeractor(const ChartData::Position::Reader &pos);
+    static QPointF posToMercator(const ChartData::Position::Reader &pos);
     static QRectF computeSymbolBox(const QTransform &transform,
                                    const QPointF &pos,
                                    SymbolImage::TextureSymbol &textureSymbol);

--- a/src/scene/tiledata.h
+++ b/src/scene/tiledata.h
@@ -3,9 +3,17 @@
 #include "annotation/annotationnode.h"
 #include "polygon/polygonnode.h"
 
+struct GeometryLayer
+{
+    QList<PolygonNode::Vertex> polygonVertices;
+};
+
 struct TileData
 {
+    // Per layer (chart) geometric objects
+    QList<GeometryLayer> geometryLayers;
+
+    // Symbolism and text for all layers
     QList<AnnotationNode::Vertex> symbolVertices;
     QList<AnnotationNode::Vertex> textVertices;
-    QList<PolygonNode::Vertex> polygonVertices;
 };


### PR DESCRIPTION
Displaying a seamless chart from multiple chart files requires
simultaneous rendering of those charts in the correct stacking order.

Up until now the following structure has been used to accomplish this:

RootNode
 ┠─PolygonNodeParent
 ┃  ┠─ Tile 1 (polygons for all charts)
 ┃  ┠─ Tile . (polygons for all charts)
 ┃  ┖─ Tile n (polygons for all charts)
 ┃
 ┠─LineNodeParent (not introduced yet)
 ┃    ┠─ Tile 1 (lines for all charts)
 ┃    ┠─ Tile . (lines for all charts)
 ┃    ┖─ Tile n (lines for all charts)
 ┠─SymbolNodeParent
 ┃  ┖─ ...
 ┖─TextNodeParent
    ┖─ ...

The z-values have been assigned so that that polygons are first ordered
based polygon type (land area, built-up area etc.) and then based on the
chart stack.

The problem with this approach is when introducing other rendering
primitives such as lines (e.g polygon borders). A line primitive might
belong to charts down in the stack that should be occluded by polygons
higher up in the stack.

With this structure that is not possible because lines are rendered on
top of all polygons.

The new structure defines GeometryNode that contains the primitives for
each tile such as polygons and lines:

RootNode
 ┠─GeometryNodes
 ┃   ┠─GeometryNode
 ┃   ┃  ┖─┰─ PolygonNode
 ┃   ┃    ┖─ LineNode
 ┃   ┠─GeometryNode .
 ┃   ┃  ┖─┰─ PolygonNode
 ┃   ┃    ┖─ LineNode
 ┃   ┖─GeometryNode n
 ┃     ┖─┰─ PolygonNode
 ┃       ┖─ LineNode
 ┠─SymbolNodeParent
 ┃  ┖─ ...
 ┖─TextNodeParent
    ┖─ ...

Symbol and text rendering is till performed across all charts for each
tile and on top of all geometric primitives.