### PR TITLE
Fix crash when loading dir containing invalid chart

### DIFF
--- a/src/tilefactory/tilefactory.cpp
+++ b/src/tilefactory/tilefactory.cpp
@@ -295,7 +295,7 @@ void TileFactory::setSources(const std::vector<TileFactory::Source> &sources)
     }
 
     m_previousTileLocations.clear();
-    m_sources = sources;
+    m_sources = qualifiedSources;
 
     std::sort(m_sources.begin(),
               m_sources.end(),


### PR DESCRIPTION
This happens when loading a directory with a chart that could not be loaded (either as encrypted or decrypted chart). Bug introduced in 5a9cbb9c.