### PR TITLE
Downgrade to windows-2019

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       SYSTEM_NAME: win64
 


### PR DESCRIPTION
capnproto provided via vcpkg won't build with MSVC 2022.