### PR TITLE
Use xdg-file-dialog for selecting chart catalog when running as snap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "MercatorTile"]
 	path = MercatorTile
 	url = https://github.com/hornang/MercatorTile
+[submodule "external/xdg-file-dialog"]
+	path = external/xdg-file-dialog
+	url = git@github.com:hornang/xdg-file-dialog.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,12 @@ find_program(RSVG-CONVERT
 
 find_package(UnixCommands)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    option(USE_XDG_FILE_DIALOG "Use xdg-file-dialog library when user selects chart catalog" OFF)
+endif()
+
 add_subdirectory(cutlines)
+add_subdirectory(external)
 add_subdirectory(oesenc)
 add_subdirectory(MercatorTile)
 add_subdirectory(src/tilefactory)
@@ -128,7 +133,7 @@ endif()
 
 target_include_directories(nautograf PRIVATE src)
 
-target_link_libraries(nautograf
+target_link_libraries(nautograf PRIVATE
     Qt6::Core
     Qt6::Quick
     Qt6::QuickControls2
@@ -144,6 +149,17 @@ install(
     RUNTIME_DEPENDENCY_SET dependency_set
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
 )
+
+if(${USE_XDG_FILE_DIALOG})
+    target_compile_definitions(nautograf PRIVATE USE_XDG_FILE_DIALOG)
+
+    target_link_libraries(nautograf PRIVATE xdg-file-dialog)
+
+    install(
+        TARGETS xdg-file-dialog
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
+    )
+endif()
 
 install(
     IMPORTED_RUNTIME_ARTIFACTS nautograf

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(${USE_XDG_FILE_DIALOG})
+    add_subdirectory(xdg-file-dialog)
+endif()

--- a/qml/FolderDialog.qml
+++ b/qml/FolderDialog.qml
@@ -1,0 +1,55 @@
+import QtQuick
+import Qt.labs.platform as QtLabs
+import org.seatronomy.nautograf
+
+Item {
+    id: root
+
+    property string title
+    property bool useXdgFileDialog: false
+    property variant parentWindow: undefined
+    property string folder
+
+    signal accepted
+
+    visible: false
+
+    Connections {
+        target: loader.item
+
+        function onAccepted() {
+            root.folder = loader.item.folder;
+            root.accepted();
+        }
+
+        function onVisibleChanged() {
+            root.visible = loader.item.visible;
+        }
+    }
+
+    Loader {
+        id: loader
+
+        onLoaded: {
+            if (root.useXdgFileDialog) {
+                item.visible = Qt.binding(function() { return root.visible })
+                item.folder = root.folder;
+                item.title = root.title;
+                item.parentWindow = parentWindow;
+            }
+        }
+
+        source: useXdgFileDialog ? "XdgFileDialogWrapper.qml" : ""
+        sourceComponent: !useXdgFileDialog ? labsFileDialog : undefined
+    }
+
+    Component {
+        id: labsFileDialog
+
+        QtLabs.FolderDialog {
+            currentFolder: root.folder
+            title: root.title
+            visible: root.visible
+        }
+    }
+}

--- a/qml/XdgFileDialogWrapper.qml
+++ b/qml/XdgFileDialogWrapper.qml
@@ -1,0 +1,6 @@
+import QtQuick
+import org.seatronomy.nautograf
+
+// Only used on Linux when compiled with option USE_XDG_FILE_DIALOG
+
+XdgFileDialog {}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -3,7 +3,6 @@ import QtQuick.Window
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Controls.Universal
-import Qt.labs.platform
 import org.seatronomy.nautograf
 
 ApplicationWindow {
@@ -50,6 +49,10 @@ ApplicationWindow {
             viewer.centerOnCatalogExtentWhenLoaded = true;
             ChartModel.setUrl(folder);
         }
+
+        useXdgFileDialog: UseXdgFileDialog
+        folder: "file:///" + ChartModel.dir
+        parentWindow: root
     }
 
     function toggleFullscreen() {

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -2,12 +2,14 @@
     <qresource prefix="/qml">
         <file>main.qml</file>
         <file>About.qml</file>
+        <file>FolderDialog.qml</file>
         <file>Viewer.qml</file>
         <file>ViewerMenu.qml</file>
         <file>ViewerMenuItem.qml</file>
         <file>ChartSelector.qml</file>
         <file>StatusBar.qml</file>
         <file>TileInfo.qml</file>
+        <file>XdgFileDialogWrapper.qml</file>
         <file>about.md</file>
         <file>graphics/title.svg</file>
     </qresource>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
     cmake-parameters:
       - -DCMAKE_TOOLCHAIN_FILE=${CRAFT_PART_SRC}/vcpkg/scripts/buildsystems/vcpkg.cmake
       - -DBUILD_TESTING=off
+      - -DUSE_XDG_FILE_DIALOG=on
       - -DCMAKE_INSTALL_PREFIX=/usr
     build-packages:
       # curl, zip, unzip and tar is needed by vcpkg:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,10 @@
 #include <QQmlApplicationEngine>
 #include <QQuickWindow>
 
+#ifdef USE_XDG_FILE_DIALOG
+#include <xdg-file-dialog/xdg-file-dialog.h>
+#endif
+
 #include "chartmodel.h"
 #include "licenses.h"
 #include "maptile.h"
@@ -93,6 +97,15 @@ int main(int argc, char *argv[])
     constexpr bool canReadEncryptedCatalog = false;
 #endif
     engine.rootContext()->setContextProperty("CanReadEncryptedCatalog", canReadEncryptedCatalog);
+
+#ifdef USE_XDG_FILE_DIALOG
+    qmlRegisterType<XdgFileDialog>("org.seatronomy.nautograf", 1, 0, "XdgFileDialog");
+    constexpr bool useXdgFileDialog = true;
+#else
+    constexpr bool useXdgFileDialog = false;
+#endif
+    engine.rootContext()->setContextProperty("UseXdgFileDialog", useXdgFileDialog);
+
     engine.load(QStringLiteral(QML_DIR) + "/main.qml");
 
     int result = application.exec();


### PR DESCRIPTION
This adds my library xdg-file-dialog to avoid usage of Qt.labs.platform.FolderDialog on Ubuntu 22.04. The build configuration is set so that the snap package uses xdg-file-dialog, but regular host OS build uses the default option which is Qt's implementation.

This change was added to avoid a gtk runtime error which is described in more detail in the xdg-file-dialog repository.