### PR TITLE
Show error message when xdg-desktop-portal is missing

### DIFF
--- a/qml/FolderDialog.qml
+++ b/qml/FolderDialog.qml
@@ -11,11 +11,13 @@ Item {
     property string folder
 
     signal accepted
+    signal error(var message)
 
     visible: false
 
     Connections {
         target: loader.item
+        ignoreUnknownSignals: true
 
         function onAccepted() {
             root.folder = loader.item.folder;
@@ -24,6 +26,10 @@ Item {
 
         function onVisibleChanged() {
             root.visible = loader.item.visible;
+        }
+
+        function onErrorOccurred() {
+            root.error("Please ensure that xdg-desktop-portal-gnome or other portal implementation is installed.");
         }
     }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -42,9 +42,33 @@ ApplicationWindow {
         UserSettings.geometry = Qt.rect(x, y, width, height);
     }
 
+    Dialog {
+        id: folderDialogErrorDialog
+
+        title: qsTr("Failed to open folder dialog")
+        anchors.centerIn: parent
+        width: 600
+
+        modal: true
+        standardButtons: Dialog.Close
+
+        Label {
+            id: errorMessageLabel
+
+            anchors.fill: parent
+            wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        }
+    }
+
     FolderDialog {
         id: folderDialog
         title: "Please choose a chart directory"
+
+        onError: function(message) {
+            errorMessageLabel.text = message;
+            folderDialogErrorDialog.open();
+        }
+
         onAccepted: function () {
             viewer.centerOnCatalogExtentWhenLoaded = true;
             ChartModel.setUrl(folder);


### PR DESCRIPTION
I suspect that a xdg-desktop-portal implementations is not installed by default on many systems. This commits add a warning message when the user tries to select chart catalog with a non-functioning desktop portal.