### PR TITLE
Remove the need for dummy symbol for labels

### DIFF
--- a/src/scene/annotations/annotater.cpp
+++ b/src/scene/annotations/annotater.cpp
@@ -104,21 +104,23 @@ Annotater::Annotations Annotater::getAnnotations(
 
         QPointF labelOffset;
 
+        optional<size_t> parentSymbolIndex;
+
         if (symbol.has_value()) {
             labelOffset = getLabelOffset(labelBoundingBox, symbol.value(), LabelPlacement::Below);
+            symbols.push_back(AnnotationSymbol { pos,
+                                                 symbol,
+                                                 nullopt,
+                                                 priority,
+                                                 collissionRule });
+            parentSymbolIndex = symbols.size() - 1;
         } else {
             labelOffset = QPointF(-labelBoundingBox.width() / 2, -labelBoundingBox.height() / 2);
         }
 
-        symbols.push_back(AnnotationSymbol { pos,
-                                             symbol,
-                                             nullopt,
-                                             priority,
-                                             collissionRule });
-
         labels.push_back(AnnotationLabel { label,
                                            pos,
-                                           symbols.size() - 1,
+                                           parentSymbolIndex,
                                            labelOffset,
                                            labelBoundingBox });
     }

--- a/src/scene/annotations/annotater.h
+++ b/src/scene/annotations/annotater.h
@@ -37,7 +37,9 @@ public:
                           other.labels.begin(),
                           other.labels.end());
             for (int i = initialLabelsSize; i < labels.size(); i++) {
-                labels[i].parentSymbolIndex += initialSymbolsSize;
+                if (labels[i].parentSymbolIndex.has_value()) {
+                    labels[i].parentSymbolIndex.value() += initialSymbolsSize;
+                }
             }
 
             return *this;

--- a/src/scene/annotations/zoomsweeper.cpp
+++ b/src/scene/annotations/zoomsweeper.cpp
@@ -219,10 +219,12 @@ void ZoomSweeper::calcLabels(const vector<AnnotationSymbol> &symbols,
         }
 
         for (auto &label : labels) {
-            const AnnotationSymbol &parentSymbol = symbols[label.parentSymbolIndex];
+            if (label.parentSymbolIndex.has_value()) {
+                const AnnotationSymbol &parentSymbol = symbols[label.parentSymbolIndex.value()];
 
-            if (!parentSymbol.minZoom.has_value() || zoom < parentSymbol.minZoom.value()) {
-                continue;
+                if (!parentSymbol.minZoom.has_value() || zoom < parentSymbol.minZoom.value()) {
+                    continue;
+                }
             }
 
             const auto pos = transform.map(label.pos) + label.offset;

--- a/src/scene/include/scene/annotations/types.h
+++ b/src/scene/include/scene/annotations/types.h
@@ -59,7 +59,7 @@ struct AnnotationLabel
 {
     Label label;
     QPointF pos;
-    size_t parentSymbolIndex;
+    std::optional<size_t> parentSymbolIndex;
     QPointF offset;
     QRectF boundingBox;
     std::optional<float> minZoom;


### PR DESCRIPTION
Up until now every label had to have a parent symbol even if that label was not associated with a graphical symbol. This commit removes this requirement by using an std::optional for the parentSymbolIndex.