### PR TITLE
Build only for amd64, arm64 and armhf on snapcraft.io

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,9 @@
 name: nautograf
 base: core22
+architectures:
+  - build-on: [amd64]
+  - build-on: [arm64]
+  - build-on: [armhf]
 adopt-info: nautograf
 summary: Tile-based nautical chart viewer
 description: >


### PR DESCRIPTION
Based on snapcraft.io these are the supported platforms. Other platforms such as riscv64 fails missing "gnome-42-*" snap.