### PR TITLE
Use older version of the cxx crate

### DIFF
--- a/src/tilefactory/rust/Cargo.toml
+++ b/src/tilefactory/rust/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["staticlib"]
 path = "lib.rs"
 
 [dependencies]
-cxx = "1.0"
+cxx = "=1.0.173"
 geo = { version = "0.28.0", default-features = false }
 
 [build-dependencies]
-cxx-build = "1.0"
+cxx-build = "=1.0.173"


### PR DESCRIPTION
Newer versions of the cxx crate (at least from 1.0.179) require rustc 1.81 or newer, which is not easily available in Snapcraft's core22 environment.